### PR TITLE
Rotation of captured images come times wrong #21

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- CAMERA -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.CAPTURE_VIDEO_OUTPUT" />


### PR DESCRIPTION
- fix autoficus for fronend camera (it's works with free focus only and does not support auto focus param)
- fix orientation for fron and back camera on captures, also it save correct image orientation to file now and displays it in original orientation without forced wrong rotation
